### PR TITLE
Add msimg32.dll to blacklist

### DIFF
--- a/mingw-bundledlls
+++ b/mingw-bundledlls
@@ -39,7 +39,7 @@ blacklist = [
     "ws2_32.dll", "comdlg32.dll", "gdi32.dll", "imm32.dll", "oleaut32.dll",
     "shell32.dll", "winmm.dll", "winspool.drv", "wldap32.dll",
     "ntdll.dll", "d3d9.dll", "mpr.dll", "crypt32.dll", "dnsapi.dll",
-    "shlwapi.dll", "version.dll", "iphlpapi.dll",
+    "shlwapi.dll", "version.dll", "iphlpapi.dll", "msimg32.dll",
 ]
 
 


### PR DESCRIPTION
Not sure what MSIMG32.dll does, but it's a windows system DLL ;-)
