### PR TITLE
Customize search paths via environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ A convenient Python3 script that copies all dependency DLLs next to the executab
   - objdump in $PATH
   - (optional) upx in $PATH
 
+## Environment Variables
+  - `$MINGW_BUNDLEDLLS_SEARCH_PATH`: Colon-separated list of paths to search for DLLs
+
 ## Usage
 
 ```

--- a/mingw-bundledlls
+++ b/mingw-bundledlls
@@ -28,10 +28,17 @@ import os.path
 import argparse
 import shutil
 
-# The mingw path matches where Fedora 21 installs mingw32
-default_path_prefixes = [
+# The mingw path matches where Fedora 21 installs mingw32; this is the default
+# fallback if no other search path is specified in $MINGW_BUNDLEDLLS_SEARCH_PATH
+DEFAULT_PATH_PREFIXES = [
     "", "/usr/bin", "/usr/i686-w64-mingw32/sys-root/mingw/bin", "/mingw64/bin",
 ]
+
+env_path_prefixes = os.environ.get('MINGW_BUNDLEDLLS_SEARCH_PATH', None)
+if env_path_prefixes is not None:
+    path_prefixes = [path for path in env_path_prefixes.split(os.pathsep) if path]
+else:
+    path_prefixes = DEFAULT_PATH_PREFIXES
 
 # This blacklist may need extending
 blacklist = [
@@ -109,7 +116,7 @@ def main():
     if args.upx and not args.copy:
         raise RuntimeError("Can't run UPX if --copy hasn't been provided.")
 
-    all_deps = set(gather_deps(args.exe_file, default_path_prefixes, []))
+    all_deps = set(gather_deps(args.exe_file, path_prefixes, []))
     all_deps.remove(args.exe_file)
 
     print("\n".join(all_deps))


### PR DESCRIPTION
Set `$MINGW_BUNDLEDLLS_SEARCH_PATH` in the environment to override the system paths where libraries are searched.

Usage example:

    export MINGW_BUNDLEDLLS_SEARCH_PATH=/opt/mingw32/bin:/usr/lib/gcc/i686-w64-mingw32/4.8:/usr/i686-w64-mingw32/lib
    ./mingw_bundledlls --copy example.exe