### PR TITLE
Do not hardcode the python3 path

### DIFF
--- a/mingw-bundledlls
+++ b/mingw-bundledlls
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # The MIT License (MIT)
 #


### PR DESCRIPTION
This fixes issues on systems where there is no system-wide Python 3 installation, or it's installed in non-standard paths.