### PR TITLE
Use a Python set for tracking dependencies

### DIFF
--- a/mingw-bundledlls
+++ b/mingw-bundledlls
@@ -88,7 +88,7 @@ def gather_deps(path, path_prefixes, seen):
             continue
 
         dep_path = find_full_path(dep, path_prefixes)
-        seen.extend([ldep])
+        seen.add(ldep)
         subdeps = gather_deps(dep_path, path_prefixes, seen)
         ret.extend(subdeps)
 
@@ -116,7 +116,7 @@ def main():
     if args.upx and not args.copy:
         raise RuntimeError("Can't run UPX if --copy hasn't been provided.")
 
-    all_deps = set(gather_deps(args.exe_file, path_prefixes, []))
+    all_deps = set(gather_deps(args.exe_file, path_prefixes, set()))
     all_deps.remove(args.exe_file)
 
     print("\n".join(all_deps))


### PR DESCRIPTION
Checking for set membership is faster than checking for list membership. Also, it's wasteful to construct a single-element list and use `list.extend()`, better to use `list.append()` or in our case `set.add()`.

This probably doesn't make much of a difference, though.