### PR TITLE
Add opengl32.dll to blacklist

### DIFF
--- a/mingw-bundledlls
+++ b/mingw-bundledlls
@@ -47,6 +47,7 @@ blacklist = [
     "shell32.dll", "winmm.dll", "winspool.drv", "wldap32.dll",
     "ntdll.dll", "d3d9.dll", "mpr.dll", "crypt32.dll", "dnsapi.dll",
     "shlwapi.dll", "version.dll", "iphlpapi.dll", "msimg32.dll", "setupapi.dll",
+    "opengl32.dll"
 ]
 
 


### PR DESCRIPTION
I've added opengl32.dll to the blacklist.