### PR TITLE
Added gdiplus.dll, usp10.dlli, and comctl32.dll to the blacklist

### DIFF
--- a/mingw-bundledlls
+++ b/mingw-bundledlls
@@ -48,7 +48,7 @@ blacklist = [
     "shell32.dll", "winmm.dll", "winspool.drv", "wldap32.dll",
     "ntdll.dll", "d3d9.dll", "mpr.dll", "crypt32.dll", "dnsapi.dll",
     "shlwapi.dll", "version.dll", "iphlpapi.dll", "msimg32.dll", "setupapi.dll",
-    "opengl32.dll", "dwmapi.dll", "uxtheme.dll", "secur32.dll"
+    "opengl32.dll", "dwmapi.dll", "uxtheme.dll", "secur32.dll", "gdiplus.dll", "usp10.dll", "comctl32.dll"
 ]
 
 


### PR DESCRIPTION
I'm not sure if you're soliciting blacklist additions, but these are from a windows 10 opengl build.