### PR TITLE
Update script "mingw-bundledll" for CMake cross compilation

### DIFF
--- a/mingw-bundledlls
+++ b/mingw-bundledlls
@@ -32,6 +32,7 @@ import shutil
 # fallback if no other search path is specified in $MINGW_BUNDLEDLLS_SEARCH_PATH
 DEFAULT_PATH_PREFIXES = [
     "", "/usr/bin", "/usr/i686-w64-mingw32/sys-root/mingw/bin", "/mingw64/bin",
+    "/usr/i686-w64-mingw32/sys-root/mingw/lib",
     "C:\\msys64\\mingw64\\bin"
 ]
 

--- a/mingw-bundledlls
+++ b/mingw-bundledlls
@@ -49,7 +49,8 @@ blacklist = [
     "shell32.dll", "winmm.dll", "winspool.drv", "wldap32.dll",
     "ntdll.dll", "d3d9.dll", "mpr.dll", "crypt32.dll", "dnsapi.dll",
     "shlwapi.dll", "version.dll", "iphlpapi.dll", "msimg32.dll", "setupapi.dll",
-    "opengl32.dll", "dwmapi.dll", "uxtheme.dll", "secur32.dll", "gdiplus.dll", "usp10.dll", "comctl32.dll"
+    "opengl32.dll", "dwmapi.dll", "uxtheme.dll", "secur32.dll", "gdiplus.dll",
+    "usp10.dll", "comctl32.dll", "wsock32.dll"
 ]
 
 


### PR DESCRIPTION
This pull request is a consequence of https://github.com/OpenSCAP/openscap/pull/925

This pull request adds following changes:
* Extends blacklist with wsock32.dll, because OpenSCAP master branch will use windows sockets 2.
* Adds a path where DLL libraries are looked because on Fedora 26 most of the DLL libraries are located in /usr/i686-w64-mingw32/sys-root/mingw/lib
* Also fixes a long line.