### PR TITLE
Try lower-cased filename

### DIFF
--- a/mingw-bundledlls
+++ b/mingw-bundledlls
@@ -58,8 +58,11 @@ blacklist = [
 def find_full_path(filename, path_prefixes):
     for path_prefix in path_prefixes:
         path = os.path.join(path_prefix, filename)
+        path_low = os.path.join(path_prefix, filename.lower())
         if os.path.exists(path):
             return path
+        if os.path.exists(path_low):
+            return path_low
 
     else:
         raise RuntimeError(


### PR DESCRIPTION
Filenames of DLLs are sometimes lower case on mingw, while the library name
is uppercase. This is OK on Windows, but easily breaks on Unix-like systems
that are case sensitive. However, Windows DLLs are almost always all lower
case on mingw.

Try to find a lower cased variant of the library in addition to the file name
listed as "DLL Name" to workaround.