### PR TITLE
Add glu32.dll to blacklist

### DIFF
--- a/mingw-bundledlls
+++ b/mingw-bundledlls
@@ -51,7 +51,7 @@ blacklist = [
     "shlwapi.dll", "version.dll", "iphlpapi.dll", "msimg32.dll", "setupapi.dll",
     "opengl32.dll", "dwmapi.dll", "uxtheme.dll", "secur32.dll", "gdiplus.dll",
     "usp10.dll", "comctl32.dll", "wsock32.dll", "netapi32.dll", "userenv.dll",
-    "avicap32.dll", "avrt.dll", "psapi.dll", "mswsock.dll"
+    "avicap32.dll", "avrt.dll", "psapi.dll", "mswsock.dll", "glu32.dll"
 ]
 
 


### PR DESCRIPTION
glu32.dll is the Windows implementation of the OpenGL utility library used by old immediate mode OpenGL applications