### PR TITLE
Add bcrypt.dll and rpcrt4.dll to the blacklist

### DIFF
--- a/mingw-bundledlls
+++ b/mingw-bundledlls
@@ -51,7 +51,8 @@ blacklist = [
     "shlwapi.dll", "version.dll", "iphlpapi.dll", "msimg32.dll", "setupapi.dll",
     "opengl32.dll", "dwmapi.dll", "uxtheme.dll", "secur32.dll", "gdiplus.dll",
     "usp10.dll", "comctl32.dll", "wsock32.dll", "netapi32.dll", "userenv.dll",
-    "avicap32.dll", "avrt.dll", "psapi.dll", "mswsock.dll", "glu32.dll"
+    "avicap32.dll", "avrt.dll", "psapi.dll", "mswsock.dll", "glu32.dll",
+    "bcrypt.dll", "rpcrt4.dll"
 ]
 
 


### PR DESCRIPTION
Hi Martin

Thanks for the really useful script!
I needed to add these two Windows DLLs to the blacklist in order to use your script on some software I originally wrote for Linux. I see that there's already a PR open containing rpcrt4.dll so you can ignore this part of my PR.

All the best,
Ivan