### PR TITLE
Add hid.dll to the blacklist

### DIFF
--- a/mingw-bundledlls
+++ b/mingw-bundledlls
@@ -52,7 +52,7 @@ blacklist = [
     "opengl32.dll", "dwmapi.dll", "uxtheme.dll", "secur32.dll", "gdiplus.dll",
     "usp10.dll", "comctl32.dll", "wsock32.dll", "netapi32.dll", "userenv.dll",
     "avicap32.dll", "avrt.dll", "psapi.dll", "mswsock.dll", "glu32.dll",
-    "bcrypt.dll", "rpcrt4.dll"
+    "bcrypt.dll", "rpcrt4.dll", "hid.dll"
 ]
 
 


### PR DESCRIPTION
Microsoft documentation that lists `hid` as a library to link against:
https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/hidsdi/nf-hidsdi-hidd_getattributes